### PR TITLE
fix compatibility with vcrpy

### DIFF
--- a/aionap/__init__.py
+++ b/aionap/__init__.py
@@ -100,8 +100,8 @@ class Resource(AttributesMixin):
             return
 
         content = await resp.read()
-        if resp.headers.get("content-type", None) and content:
-            content_type = resp.headers.get("content-type").split(";")[0].strip()
+        if resp.headers.get("Content-Type", None) and content:
+            content_type = resp.headers.get("Content-Type").split(";")[0].strip()
 
             try:
                 # get serializer


### PR DESCRIPTION
aionap currently breaks apart when someone uses vcrpy (http mocking
framework) as part of some unit tests.

In particular, the vcrpy magic behind replaying a HTTP response turns
the response headers returned by aiohttp into a normal dict. aiohttp
normally returns CIMultiDictProxy objects for those which allows one
to lookup headers case-insensitive.

vcrpy also makes sure that the recorded headers follow a Camel-case
convention (e.g. content-type is recorded as Content-Type)

This conversion now breaks the response decoding because it looks for a
"content-type" response header, although only "Content-Type" is present.

This commit changes the response header lookup during response decoding
so that it looks for "Content-Type". When doing "real" requests nothing
changes, as aiohttp correctly does the header lookups case-insensitive.
When vcrpy is enabled and used to replay recorded requests, the returned
responses are still decoded correctly that way.